### PR TITLE
Fix SQLite layer import handling

### DIFF
--- a/bo_projektstart/bo_projektstart.py
+++ b/bo_projektstart/bo_projektstart.py
@@ -872,6 +872,71 @@ class BoProjektstartPlugin:
             return candidate
         return QgsRasterLayer(source, name)
 
+    def _create_sqlite_layer(self, layer: Dict):
+        name = layer.get("name", "Layer")
+        source = str(layer.get("source", "")).strip()
+        table = str(layer.get("table", "")).strip()
+        geometry_column = str(layer.get("geometry_column", "")).strip()
+        key_column = str(layer.get("key_column", "")).strip()
+        sql_filter = str(layer.get("where", "")).strip()
+        explicit_uri = str(layer.get("uri", "")).strip()
+
+        spatialite_uri = explicit_uri or self._build_sqlite_uri(source, table, geometry_column, key_column, sql_filter)
+
+        if table and not geometry_column:
+            ogr_source = f"{source}|layername={table}" if source else ""
+            if ogr_source:
+                ogr_layer = QgsVectorLayer(ogr_source, name, "ogr")
+                if ogr_layer.isValid():
+                    return ogr_layer
+
+        if spatialite_uri:
+            sqlite_layer = QgsVectorLayer(spatialite_uri, name, "spatialite")
+            if sqlite_layer.isValid():
+                return sqlite_layer
+
+        if table:
+            ogr_source = f"{source}|layername={table}" if source else ""
+            if ogr_source:
+                ogr_layer = QgsVectorLayer(ogr_source, name, "ogr")
+                if ogr_layer.isValid():
+                    return ogr_layer
+
+        if explicit_uri:
+            ogr_layer = QgsVectorLayer(explicit_uri, name, "ogr")
+            if ogr_layer.isValid():
+                return ogr_layer
+
+        if source:
+            ogr_layer = QgsVectorLayer(source, name, "ogr")
+            if ogr_layer.isValid():
+                return ogr_layer
+
+        return None
+
+    def _build_sqlite_uri(
+        self,
+        source: str,
+        table: str,
+        geometry_column: str,
+        key_column: str,
+        sql_filter: str,
+    ) -> str:
+        if not source:
+            return ""
+
+        if table:
+            parts = [f"dbname='{source}'", f'table="{table}"']
+            if geometry_column:
+                parts[-1] = f'{parts[-1]} ({geometry_column})'
+            if sql_filter:
+                parts.append(f"sql={sql_filter}")
+            if key_column:
+                parts.append(f"key='{key_column}'")
+            return " ".join(parts)
+
+        return f"dbname='{source}'"
+
     def _build_postgres_uri(self, layer: Dict) -> str:
         host = str(layer.get("host", ""))
         port = str(layer.get("port", "5432"))


### PR DESCRIPTION
### Motivation
- Ein `AttributeError` trat auf, weil `source_type: "sqlite"/"spatialite"` zwar in `_create_non_virtual_layer` behandelt, die aufgerufene Methode aber nicht implementiert war.  
- Das Plugin-Dokument beschreibt, dass SQLite/SpatiaLite-Quellen mit und ohne Geometrie unterstützt werden müssen, inklusive einer spezifischen Lade-Reihenfolge und URI-Optionen.

### Description
- Implementiert `def _create_sqlite_layer(self, layer: Dict)` mit der dokumentierten Lade-Reihenfolge: bei `table` ohne `geometry_column` wird zuerst `source|layername=<table>` via OGR versucht.  
- Unterstützt explizite `uri`, baut mit `def _build_sqlite_uri(...) -> str` eine Spatialite/SQLite-URI aus `source`, `table`, `geometry_column`, `key_column` und `where` und versucht den Spatialite-Provider vor OGR-Fallbacks.  
- Fügt mehrere Fallbacks hinzu (spatialite provider, OGR `layername`, explicit `uri`, generischer OGR `source`) und gibt `None` zurück, wenn kein Layer geladen werden kann.  
- Geänderte Datei: `bo_projektstart/bo_projektstart.py` (Hinzufügung von `_create_sqlite_layer` und `_build_sqlite_uri`, Integration in bestehende Lade-Logik).

### Testing
- `python -m py_compile bo_projektstart/bo_projektstart.py` wurde ausgeführt und schlug fehlfrei durch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba578f53e88328a90aad209b779ea0)